### PR TITLE
Update clojure_keybindings.sublime-keymap

### DIFF
--- a/clojure_keybindings.sublime-keymap
+++ b/clojure_keybindings.sublime-keymap
@@ -33,7 +33,7 @@
   { "keys": ["alt+super+p"], "command": "run_command_in_repl", "args": {"command": "(pp)"}},
 
   // Refresh code then run tests from the current namespace in repl
-  { "keys": ["alt+super+x"], "command": "run_command_in_namespace_in_repl", "args": {"command": "(run-tests)", "refresh_namespaces": true}},
+  { "keys": ["alt+super+x"], "command": "run_command_in_namespace_in_repl", "args": {"command": "(do (require 'clojure.test) (clojure.test/run-tests))", "refresh_namespaces": true}},
 
   // Runs the single selected test. You must select the test name.
   { "keys": ["alt+super+t"], "command": "test_selected_var_in_repl", "args": {"refresh_namespaces": false}},


### PR DESCRIPTION
This just makes the Command-Option-x `run-tests` call more explicit so that it works with namespaces that don't `(:require [clojure.test :refer :all])` in their `ns` forms.
